### PR TITLE
Added [#delegate_remote] to delegate for remote types

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,34 @@ trait Display {
 pub struct WrappedCat(Cat);
 ```
 
+### For remote types `#[delegate_remote]`
+
+If you want to make an existing type that lives outside you crate delegate, you can do so by copy-pasting it's definition into your code and using the `#[delegate_remote]` attribute (see [full code sample](./ambassador/tests/run-pass/delegate_remote.rs)):
+
+If the type is a struct, not all the fields have to be public, only the ones being delegated to.
+
+```rust
+mod wrapped {
+    use super::*;
+    pub struct WrappedAnimals<A> {
+        pub foo: Cat,
+        pub bar: A,
+        baz: u32, // private field
+    }
+}
+
+use wrapped::*;
+
+#[delegate_remote]
+#[delegate(Shout, target = "bar")]
+struct WrappedAnimals<A: Shout> {
+    foo: Cat,
+    bar: A,
+    // We don't even have to include baz since we don't delegate to it
+}
+```
+
+Note: Because of the orphan rule `#[delegatable_trait_remote]` and `#[delegate_remote]` can't be combined
 
 ## Usage Examples
 

--- a/ambassador/src/lib.rs
+++ b/ambassador/src/lib.rs
@@ -15,6 +15,11 @@ pub fn delegate_macro(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn delegate_remote(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    crate::derive::delegate_macro(input)
+}
+
+#[proc_macro_attribute]
 pub fn delegatable_trait(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let original_item: syn::ItemTrait = syn::parse(item).unwrap();
     let register_trait = build_register_trait(&original_item);

--- a/ambassador/tests/run-pass/delegate_remote.rs
+++ b/ambassador/tests/run-pass/delegate_remote.rs
@@ -1,0 +1,56 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, delegate_remote};
+
+#[delegatable_trait]
+pub trait Shout {
+    fn shout(&self, input: &str) -> String;
+}
+
+pub struct Cat;
+
+impl Shout for Cat {
+    fn shout(&self, input: &str) -> String {
+        format!("{} - meow!", input)
+    }
+}
+
+pub struct Dog;
+
+impl Shout for Dog {
+    fn shout(&self, input: &str) -> String {
+        format!("{} - wuff!", input)
+    }
+}
+
+mod wrapped {
+    use super::{Cat};
+    pub struct WrappedAnimals<A> {
+        pub foo: Cat,
+        pub bar: A,
+        baz: u32, // private field
+    }
+
+    impl<A> WrappedAnimals<A> {
+        pub fn new(foo: Cat, bar: A) -> Self {
+            WrappedAnimals{foo, bar, baz: 13}
+        }
+    }
+}
+
+use wrapped::*;
+
+#[delegate_remote]
+#[delegate(Shout, target = "bar")]
+struct WrappedAnimals<A: Shout> {
+    foo: Cat,
+    bar: A,
+}
+
+
+pub fn main() {
+    let foo_animal = WrappedAnimals::new(Cat, Cat);
+    println!("{}", foo_animal.shout("BAR"));
+    let bar_animal = WrappedAnimals::new(Cat, Dog);
+    println!("{}", bar_animal.shout("BAR"));
+}


### PR DESCRIPTION
Fixes #4
Adds support for making an existing type that lives outside the current crate delegate traits to it’s members