### PR TITLE
Generics2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.52.0
+          - 1.53.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.52.0
+          - 1.53.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.40.0
+          - 1.52.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -30,7 +30,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.40.0
+          - 1.52.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.40.0
+          - 1.52.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -29,7 +29,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.40.0
+          - 1.52.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.52.0
+          - 1.53.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.52.0
+          - 1.53.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
-          - 1.53.0
+          - stable # It's useful to test applications of these macros to newer features so a 1.53 test doesn't work
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ impl<T: Display> Shout<T> for Cat {
 }
 
 #[derive(Delegate)]
-#[delegate(Shout<X>)] // <-------- `X` signifies we want to be as generic as possible
+#[delegate(Shout<X>, generics = "X")] // <-------- X is fully generic
 // The automatic where clause ensures X: Display
-// We could also use #[delegate(Shout<& 'x str>)] to only delegate for &str
+// We could also use #[delegate(Shout<& 'a str>, generics = "'a")] to only delegate for &str
 pub struct WrappedCat(Cat);
 ```
 

--- a/ambassador/Cargo.toml
+++ b/ambassador/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ambassador"
 version = "0.3.0"
 authors = ["Maximilian Goisser <goisser94@gmail.com>", "David Ewert <dewert10@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Trait implementation delegation via procedural macros"
 keywords = ["trait", "delegate", "delegation", "macros", "proc-macros"]
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ backward_compatible = []
 syn = { version = "1.0.8", features = ["full", "extra-traits", "visit"] }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
-itertools = "0.8.*"
-bytemuck = {version = "1.4.0", features = ["derive"]}
+itertools = "0.10.3"
+bytemuck = {version = "1.7.3", features = ["derive"]}
 
 [dev-dependencies]
 compiletest_rs = { version = "0.3.25", features = [ "stable" ]}

--- a/ambassador/Cargo.toml
+++ b/ambassador/Cargo.toml
@@ -20,8 +20,8 @@ backward_compatible = []
 syn = { version = "1.0.8", features = ["full", "extra-traits", "visit"] }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
-itertools = "0.10.3"
-bytemuck = {version = "1.7.3", features = ["derive"]}
+itertools = "0.8.*"
+bytemuck = {version = "1.4.0", features = ["derive"]}
 
 [dev-dependencies]
 compiletest_rs = { version = "0.3.25", features = [ "stable" ]}

--- a/ambassador/Cargo.toml
+++ b/ambassador/Cargo.toml
@@ -20,7 +20,6 @@ backward_compatible = []
 syn = { version = "1.0.8", features = ["full", "extra-traits", "visit"] }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
-lazy-regex = "2.2.2"
 itertools = "0.10.3"
 bytemuck = {version = "1.7.3", features = ["derive"]}
 

--- a/ambassador/Cargo.toml
+++ b/ambassador/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ambassador"
 version = "0.3.0"
 authors = ["Maximilian Goisser <goisser94@gmail.com>", "David Ewert <dewert10@gmail.com>"]
-edition = "2021"
+edition = "2018"
 description = "Trait implementation delegation via procedural macros"
 keywords = ["trait", "delegate", "delegation", "macros", "proc-macros"]
 license = "MIT OR Apache-2.0"

--- a/ambassador/src/derive.rs
+++ b/ambassador/src/derive.rs
@@ -1,4 +1,5 @@
 use super::register::{macro_name, match_name};
+use super::util::my_matches as matches;
 use itertools::Itertools;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2, TokenTree};

--- a/ambassador/src/derive.rs
+++ b/ambassador/src/derive.rs
@@ -1,5 +1,4 @@
 use super::register::{macro_name, match_name};
-use super::util::my_matches as matches;
 use itertools::Itertools;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2, TokenTree};

--- a/ambassador/src/lib.rs
+++ b/ambassador/src/lib.rs
@@ -56,16 +56,16 @@
 //!
 //! // No automatic where clause provided for target = "self"
 //! #[delegate_remote]
-//! #[delegate(Get<X>, target = "self", where = "K: Hash + Eq + Borrow<X>, S: BuildHasher, X: Hash + Eq + ?Sized")]
+//! #[delegate(Get<X>, target = "self", generics = "X", where = "K: Hash + Eq + Borrow<X>, S: BuildHasher, X: Hash + Eq + ?Sized")]
 //! struct HashMap<K, V, S>();
 //!
 //! #[delegate_remote]
-//! #[delegate(Get<X>, target = "self", where = "K: Ord + Borrow<X>, X: Ord + ?Sized")]
+//! #[delegate(Get<X>, target = "self", generics = "X", where = "K: Ord + Borrow<X>, X: Ord + ?Sized")]
 //! struct BTreeMap<K, V>();
 //!
 //! #[derive(Delegate)]
 //! #[delegate(Map)]
-//! #[delegate(Get<X>, where = "X: ?Sized, B: Map<K=A::K, V=A::V>")]  //auto where clause misses required on super trait
+//! #[delegate(Get<X>, generics = "X", where = "X: ?Sized, B: Map<K=A::K, V=A::V>")]  //auto where clause misses required on super trait
 //! pub enum Either<A, B> {
 //!     Left(A),
 //!     Right(B),
@@ -208,13 +208,12 @@ use crate::register::build_register_trait;
 /// ```
 ///
 ///
-/// #### `#[delegate(Shout<X>)]` - trait generics
+/// #### `#[delegate(Shout<X>, generics = "X")]` - trait generics
 ///
 /// We can also delegate traits with generics.
-/// When doing this all instances of `X` and `'x` followed by arbitrary digits eg. `X0` `X12` `'x3` are treated as maximally generic.
+/// The type parameters listed in the `generics` key are treated as fully generic.
 /// The automatically added where clause ensures they are valid for the inner type being delegated to.
 /// Explict where clauses to further refine these types can be added as normal.
-/// Specific types can be used instead of `X` to only derive for those.
 ///
 /// ```
 /// use ambassador::{delegatable_trait, Delegate};
@@ -234,14 +233,14 @@ use crate::register::build_register_trait;
 /// }
 ///
 /// #[derive(Delegate)]
-/// #[delegate(Shout<X>)] // <-------- `X` signifies we want to be as generic as possible
+/// #[delegate(Shout<X>, generics = "X")] // <-------- `X` is fully generic
 /// // The automatic where clause ensures X: Display
-/// // We could also use #[delegate(Shout<& 'x str>)] to only delegate for &str
+/// // We could also use #[delegate(Shout<& 'a str>, generics = "'a")] to only delegate for &str
 /// pub struct WrappedCat(Cat);
 /// ```
 #[proc_macro_derive(Delegate, attributes(delegate))]
 pub fn delegate_macro(input: TokenStream) -> TokenStream {
-    crate::derive::delegate_macro(input)
+    derive::delegate_macro(input)
 }
 
 /// Make an existing type that lives outside you crate delegate traits to it's members
@@ -286,7 +285,7 @@ pub fn delegate_macro(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn delegate_remote(_attr: TokenStream, input: TokenStream) -> TokenStream {
-    crate::derive::delegate_macro(input)
+    derive::delegate_macro(input)
 }
 
 /// Make a trait available for delegation
@@ -324,13 +323,13 @@ pub fn delegatable_trait(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// #[delegatable_trait_remote]
 /// trait Display {
-///     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error>;
+///     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error>;
 /// }
 ///
 /// struct Cat;
 ///
 /// impl Display for Cat {
-///     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error>{
+///     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error>{
 ///         f.write_str("Cat")
 ///     }
 /// }

--- a/ambassador/src/lib.rs
+++ b/ambassador/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! Delegating the implementation of traits to enum variants or fields of a struct normally requires a lot of boilerplate code. Ambassador is an attempt to eliminate that boilerplate by deriving the delegating trait implementation via procedural macros.
 //!
-//! **The minimum supported Rust version is 1.40.0.**
+//! **The minimum supported Rust version is 1.52.0.**
 //!
 //! See individual macro documentation for detailed instructions.
 //!

--- a/ambassador/src/lib.rs
+++ b/ambassador/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! Delegating the implementation of traits to enum variants or fields of a struct normally requires a lot of boilerplate code. Ambassador is an attempt to eliminate that boilerplate by deriving the delegating trait implementation via procedural macros.
 //!
-//! **The minimum supported Rust version is 1.52.0.**
+//! **The minimum supported Rust version is 1.53.0.**
 //!
 //! See individual macro documentation for detailed instructions.
 //!

--- a/ambassador/src/lib.rs
+++ b/ambassador/src/lib.rs
@@ -77,6 +77,17 @@
 //!     assert_eq!(my_map.get("a"), Some(&1));
 //! }
 //! ```
+//!
+//! # Backwards Compatibility
+//! Since delegateable traits from one crate can be used in anther crate backwards compatibility of switching to 0.3.x depends on the use case
+//! ## Self Contained Crate
+//! Switching to 0.3.x should just work,
+//! in this case it safe to disable the "backward_compatible" feature
+//! ## Library with public delegatable traits
+//! Make sure use the "backward_compatible" feature (enabled by default),
+//! this makes sure users of your library using an older version of ambassador aren't affected by the upgrade
+//! ## Users of a library with public delegatable traits
+//! Try to use the same version of ambassador as the library you're using
 
 extern crate proc_macro;
 

--- a/ambassador/src/register.rs
+++ b/ambassador/src/register.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
@@ -31,11 +30,16 @@ pub fn build_register_trait(original_item: &ItemTrait) -> TokenStream {
         .map(param_to_matcher)
         .collect();
 
-    let (struct_items, enum_items, self_items): (Vec<_>, Vec<_>, Vec<_>) = original_item
+    let (mut struct_items, mut enum_items, mut self_items) = (vec![], vec![], vec![]);
+    original_item
         .items
         .iter()
         .map(|item| build_trait_items(item, trait_ident, &gen_idents))
-        .multiunzip();
+        .for_each(|(st, en, se)| {
+            struct_items.push(st);
+            enum_items.push(en);
+            self_items.push(se);
+        });
 
     let assoc_ty_bounds = make_assoc_ty_bound(&original_item.items, original_item, &match_name);
 

--- a/ambassador/src/register.rs
+++ b/ambassador/src/register.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
@@ -30,16 +31,11 @@ pub fn build_register_trait(original_item: &ItemTrait) -> TokenStream {
         .map(param_to_matcher)
         .collect();
 
-    let (mut struct_items, mut enum_items, mut self_items) = (vec![], vec![], vec![]);
-    original_item
+    let (struct_items, enum_items, self_items): (Vec<_>, Vec<_>, Vec<_>) = original_item
         .items
         .iter()
         .map(|item| build_trait_items(item, trait_ident, &gen_idents))
-        .for_each(|(st, en, se)| {
-            struct_items.push(st);
-            enum_items.push(en);
-            self_items.push(se);
-        });
+        .multiunzip();
 
     let assoc_ty_bounds = make_assoc_ty_bound(&original_item.items, original_item, &match_name);
 

--- a/ambassador/src/util.rs
+++ b/ambassador/src/util.rs
@@ -24,15 +24,3 @@ where
         }
     }
 }
-
-// Copy of matches! to be compatible with 1.40
-macro_rules! my_matches {
-    ($expression:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
-        match $expression {
-            $( $pattern )|+ $( if $guard )? => true,
-            _ => false
-        }
-    }
-}
-
-pub(crate) use my_matches;

--- a/ambassador/src/util.rs
+++ b/ambassador/src/util.rs
@@ -24,3 +24,15 @@ where
         }
     }
 }
+
+// Copy of matches! to be compatible with 1.40
+macro_rules! my_matches {
+    ($expression:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
+        match $expression {
+            $( $pattern )|+ $( if $guard )? => true,
+            _ => false
+        }
+    }
+}
+
+pub(crate) use my_matches;

--- a/ambassador/tests/compile-fail/delegate_self_fail.rs
+++ b/ambassador/tests/compile-fail/delegate_self_fail.rs
@@ -1,10 +1,10 @@
 extern crate ambassador;
 
-use std::collections::{HashMap, BTreeMap};
-use std::hash::Hash;
-use std::cmp::{Eq, Ord};
-use std::borrow::Borrow;
 use ambassador::{delegatable_trait, delegate_remote, Delegate};
+use std::borrow::Borrow;
+use std::cmp::{Eq, Ord};
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
 
 #[delegatable_trait]
 pub trait Map {
@@ -17,35 +17,34 @@ pub trait Get<Q: ?Sized>: Map {
     fn get(&self, k: &Q) -> Option<&Self::V>;
 }
 
-impl<K, V, S> Map for HashMap<K, V, S>  {
+impl<K, V, S> Map for HashMap<K, V, S> {
     type K = K;
     type V = V;
 }
 
-impl<K, V> Map for BTreeMap<K, V>  {
+impl<K, V> Map for BTreeMap<K, V> {
     type K = K;
     type V = V;
 }
-
 
 #[delegate_remote]
-#[delegate(Get<X>, target = "self", where = "K: Hash + Eq + Borrow<X>, X: Hash + Eq + ?Sized")] //Forgot S: BuildHasher
+#[delegate(Get<X>, target = "self", generics = "X", where = "K: Hash + Eq + Borrow<X>, X: Hash + Eq + ?Sized")] //Forgot S: BuildHasher
 struct HashMap<K, V, S>();
 
 #[delegate_remote]
-#[delegate(Get<X>, target = "self", where = "K: Ord + Borrow<X>, X: Ord + ?Sized")]
+#[delegate(Get<X>, target = "self", generics = "X", where = "K: Ord + Borrow<X>, X: Ord + ?Sized")]
 struct BTreeMap<K, V>();
 
 #[derive(Delegate)]
 #[delegate(Map)]
-#[delegate(Get<X>, where = "X: ?Sized, A: Map, B: Map<K=A::K, V=A::V>")]
+#[delegate(Get<X>, generics = "X", where = "X: ?Sized, A: Map, B: Map<K=A::K, V=A::V>")]
 pub enum Either<A, B> {
     Left(A),
     Right(B),
 }
 
-
 pub fn main() {
-    let my_map: Either<HashMap<&'static str, u32>, BTreeMap<&'static str, u32>> = Either::Left([("a", 1)].into());
+    let my_map: Either<HashMap<&'static str, u32>, BTreeMap<&'static str, u32>> =
+        Either::Left([("a", 1)].into());
     println!("{:?}", my_map.get("a"));
 }

--- a/ambassador/tests/compile-fail/generic_trait_bad_where.rs
+++ b/ambassador/tests/compile-fail/generic_trait_bad_where.rs
@@ -1,7 +1,7 @@
 extern crate ambassador;
 
-use std::collections::{BTreeMap, HashMap};
 use ambassador::*;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Index;
 
 #[delegatable_trait_remote]
@@ -10,9 +10,8 @@ pub trait Index<Idx: ?Sized> {
     fn index(&self, index: Idx) -> &Self::Output;
 }
 
-
 #[derive(Delegate)]
-#[delegate(Index<X>, where = "X: Into<u32>")]
+#[delegate(Index<X>, generics = "X", where = "X: Into<u32>")]
 pub enum SomeMap<K, V> {
     Hash(HashMap<K, V>),
     BTree(BTreeMap<K, V>),

--- a/ambassador/tests/compile-fail/taxonomy_fail.rs
+++ b/ambassador/tests/compile-fail/taxonomy_fail.rs
@@ -1,7 +1,7 @@
 extern crate ambassador;
 
 use ambassador::{delegatable_trait, Delegate};
-use std::any::{type_name};
+use std::any::type_name;
 
 #[delegatable_trait]
 pub trait Taxonomy<E> {
@@ -45,19 +45,23 @@ impl Taxonomy<Kingdom> for Reptile {
 }
 
 impl<E: Base + Taxonomy<Class>> Taxonomy<Kingdom> for E
-    where <E as Taxonomy<Class>>::Res : Taxonomy<Kingdom> {
+where
+    <E as Taxonomy<Class>>::Res: Taxonomy<Kingdom>,
+{
     type Res = <<E as Taxonomy<Class>>::Res as Taxonomy<Kingdom>>::Res;
 }
 
-
 #[derive(Delegate)]
-#[delegate(Taxonomy<X>)]
+#[delegate(Taxonomy<X>, generics = "X")]
 pub enum Either<A, B> {
     A(A),
     B(B),
 }
 
 pub fn main() {
-    assert_eq!(type_name::<<Either<Cat, Alligator> as Taxonomy<Class>>::Res>(), type_name::<Mammal>());
-    //~^ ERROR type mismatch resolving `<Cat as Taxonomy<Class>>::Res == Reptile`
+    assert_eq!(
+        type_name::<<Either<Cat, Alligator> as Taxonomy<Class>>::Res>(),
+        //~^ ERROR type mismatch resolving `<Cat as Taxonomy<Class>>::Res == Reptile`
+        type_name::<Mammal>()
+    );
 }

--- a/ambassador/tests/run-pass/enum_associated_constant.rs
+++ b/ambassador/tests/run-pass/enum_associated_constant.rs
@@ -1,13 +1,12 @@
 extern crate ambassador;
 
-use std::collections::{BTreeMap, HashMap};
 use ambassador::*;
+use std::collections::{BTreeMap, HashMap};
 
 #[delegatable_trait]
 pub trait IntoMany<N> {
     const N: usize;
 }
-
 
 impl IntoMany<u8> for u32 {
     const N: usize = 4;
@@ -25,15 +24,13 @@ impl IntoMany<u8> for char {
     const N: usize = 4;
 }
 
-
 #[derive(Delegate)]
-#[delegate(IntoMany<X>)]
+#[delegate(IntoMany<X>, generics = "X")]
 pub enum CharOrU32 {
     Char(char),
     U32(u32),
 }
 
-
 fn main() {
-    assert_eq!( <CharOrU32 as IntoMany<u8>>::N, 4);
+    assert_eq!(<CharOrU32 as IntoMany<u8>>::N, 4);
 }

--- a/ambassador/tests/run-pass/generic_trait_any.rs
+++ b/ambassador/tests/run-pass/generic_trait_any.rs
@@ -1,7 +1,7 @@
 extern crate ambassador;
 
-use std::collections::{BTreeMap, HashMap};
 use ambassador::*;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Index;
 
 #[delegatable_trait_remote]
@@ -10,9 +10,8 @@ pub trait Index<Idx: ?Sized> {
     fn index(&self, index: Idx) -> &Self::Output;
 }
 
-
 #[derive(Delegate)]
-#[delegate(Index<X>, where = "X: Copy")]
+#[delegate(Index<X>, generics = "X", where = "X: Copy")]
 pub enum SomeMap<K, V> {
     Hash(HashMap<K, V>),
     BTree(BTreeMap<K, V>),

--- a/ambassador/tests/run-pass/generic_trait_complex.rs
+++ b/ambassador/tests/run-pass/generic_trait_complex.rs
@@ -17,9 +17,8 @@ impl<A: Display, B: Display> Shout<(A, B)> for Cat {
 }
 
 #[derive(Delegate)]
-#[delegate(Shout<(X1, &'x str)>, target="0")]
+#[delegate(Shout<(Y, &'a str)>, generics = "'a, Y", target="0")]
 pub struct WrappedCat(Cat, ());
-
 
 fn main() {
     let c = WrappedCat(Cat, ());

--- a/ambassador/tests/run-pass/generic_trait_lifetime.rs
+++ b/ambassador/tests/run-pass/generic_trait_lifetime.rs
@@ -17,7 +17,7 @@ impl<'a, E> Ref<'a> for &'a E {
 }
 
 #[derive(Delegate)]
-#[delegate(Ref<'x>)]
+#[delegate(Ref<'x>, generics = "'x")]
 struct WrapRef<'a, T>(&'a T);
 
 fn main() {
@@ -25,4 +25,3 @@ fn main() {
     let y = WrapRef(&x);
     assert_eq!(*y.deref(), 5)
 }
-

--- a/ambassador/tests/run-pass/muti-feature.rs
+++ b/ambassador/tests/run-pass/muti-feature.rs
@@ -1,10 +1,10 @@
 extern crate ambassador;
 
-use std::collections::{HashMap, BTreeMap};
-use std::hash::{Hash, BuildHasher};
-use std::cmp::{Eq, Ord};
-use std::borrow::Borrow;
 use ambassador::{delegatable_trait, delegate_remote, Delegate};
+use std::borrow::Borrow;
+use std::cmp::{Eq, Ord};
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{BuildHasher, Hash};
 
 #[delegatable_trait]
 pub trait Map {
@@ -17,36 +17,35 @@ pub trait Get<Q: ?Sized>: Map {
     fn get(&self, k: &Q) -> Option<&Self::V>;
 }
 
-impl<K, V, S> Map for HashMap<K, V, S>  {
+impl<K, V, S> Map for HashMap<K, V, S> {
     type K = K;
     type V = V;
 }
 
-impl<K, V> Map for BTreeMap<K, V>  {
+impl<K, V> Map for BTreeMap<K, V> {
     type K = K;
     type V = V;
 }
-
 
 // No automatic where clause provided for target = "self"
 #[delegate_remote]
-#[delegate(Get<X>, target = "self", where = "K: Hash + Eq + Borrow<X>, S: BuildHasher, X: Hash + Eq + ?Sized")]
+#[delegate(Get<X>, generics = "X", target = "self", where = "K: Hash + Eq + Borrow<X>, S: BuildHasher, X: Hash + Eq + ?Sized")]
 struct HashMap<K, V, S>();
 
 #[delegate_remote]
-#[delegate(Get<X>, target = "self", where = "K: Ord + Borrow<X>, X: Ord + ?Sized")]
+#[delegate(Get<X>, generics = "X", target = "self", where = "K: Ord + Borrow<X>, X: Ord + ?Sized")]
 struct BTreeMap<K, V>();
 
 #[derive(Delegate)]
 #[delegate(Map)]
-#[delegate(Get<X>, where = "X: ?Sized, A: Map, B: Map<K=A::K, V=A::V>")]  //auto where clause misses required on super trait
+#[delegate(Get<X>, generics = "X", where = "X: ?Sized, A: Map, B: Map<K=A::K, V=A::V>")] //auto where clause misses required on super trait
 pub enum Either<A, B> {
     Left(A),
     Right(B),
 }
 
-
 pub fn main() {
-    let my_map: Either<HashMap<&'static str, u32>, BTreeMap<&'static str, u32>> = Either::Left([("a", 1)].into());
+    let my_map: Either<HashMap<&'static str, u32>, BTreeMap<&'static str, u32>> =
+        Either::Left([("a", 1)].into());
     println!("{:?}", my_map.get("a"));
 }

--- a/ambassador/tests/run-pass/taxonomy.rs
+++ b/ambassador/tests/run-pass/taxonomy.rs
@@ -1,7 +1,7 @@
 extern crate ambassador;
 
 use ambassador::{delegatable_trait, Delegate};
-use std::any::{type_name};
+use std::any::type_name;
 
 #[delegatable_trait]
 pub trait Taxonomy<E> {
@@ -45,19 +45,26 @@ impl Taxonomy<Kingdom> for Reptile {
 }
 
 impl<E: Base + Taxonomy<Class>> Taxonomy<Kingdom> for E
-    where <E as Taxonomy<Class>>::Res : Taxonomy<Kingdom> {
+where
+    <E as Taxonomy<Class>>::Res: Taxonomy<Kingdom>,
+{
     type Res = <<E as Taxonomy<Class>>::Res as Taxonomy<Kingdom>>::Res;
 }
 
-
 #[derive(Delegate)]
-#[delegate(Taxonomy<X>)]
+#[delegate(Taxonomy<X>, generics = "X")]
 pub enum Either<A, B> {
     A(A),
     B(B),
 }
 
 pub fn main() {
-    assert_eq!(type_name::<<Either<Cat, Dog> as Taxonomy<Class>>::Res>(), type_name::<Mammal>());
-    assert_eq!(type_name::<<Either<Cat, Alligator> as Taxonomy<Kingdom>>::Res>(), type_name::<Animal>());
+    assert_eq!(
+        type_name::<<Either<Cat, Dog> as Taxonomy<Class>>::Res>(),
+        type_name::<Mammal>()
+    );
+    assert_eq!(
+        type_name::<<Either<Cat, Alligator> as Taxonomy<Kingdom>>::Res>(),
+        type_name::<Animal>()
+    );
 }


### PR DESCRIPTION
Switched how fully generic type parameters are handled.
Instead of treating "X\d*" names as fully generic with could potentially be a problem if someone had a struct named X for some reason.  Fully generic names a listed specifically in there own section.