### PR TITLE
Permit delegating to a more complicated expression (via macro call)

### DIFF
--- a/ambassador/src/register.rs
+++ b/ambassador/src/register.rs
@@ -43,7 +43,7 @@ pub fn build_register_trait(original_item: &ItemTrait) -> TokenStream {
         #[doc = concat!("A macro to be used by [`ambassador::Delegate`] to delegate [`", stringify!(#trait_ident), "`]")]
         #[macro_export]
         macro_rules! #macro_name {
-            (body_struct(<#gen_matcher>, $ty:ty, $field_ident:tt)) => {
+            (body_struct(<#gen_matcher>, $ty:ty, $($field_ident:tt)*)) => {
                 #(#struct_items)*
             };
             (body_enum(<#gen_matcher>, $ty:ty, ($( $other_tys:ty ),+), ($( $variants:path ),+))) => {
@@ -65,7 +65,7 @@ pub fn build_register_trait(original_item: &ItemTrait) -> TokenStream {
         let legacy_macros = quote! {
             #[macro_export]
             macro_rules! #struct_name {
-                ($field_ident:tt) => {#macro_name!{body_struct(<>, (), $field_ident)}};
+                ($($field_ident:tt)*) => {#macro_name!{body_struct(<>, (), $($field_ident)*)}};
             }
             #[macro_export]
             macro_rules! #enum_name {
@@ -205,7 +205,7 @@ fn build_trait_items(
             (
                 {
                     let method_invocation =
-                        build_method_invocation(original_method, &quote!(self.$field_ident));
+                        build_method_invocation(original_method, &quote!(self.$($field_ident)*));
                     quote! {
                         #method_sig {
                             #method_invocation


### PR DESCRIPTION
In my application, I want to delegate to a more compliated expression than simply a single field.  So I have done this:

```
impl Piece {
  fn inner(&self) -> &dyn PieceTrait {
    self.ipc
      .as_ref()
      .expect("attempted to invoke unresolved fastsplit::Piece")
      .p.direct_trait_access()
  }
}

impl PieceTrait for Piece {
  ambassador_impl_PieceTrait_body_single_struct!{ inner() }
}
```

This works great.  But I had to alter ambassador to permit more than just a simple identifier as the delegate.

I pasted the whole of `Piece::inner()` to show that it can do arbitrary stuff without having to complicate the macrology.  The only requirement for the delegate argument is that appending it to `self.` produces a trait object expression.

(I hope this passes the github CI.  I tried to run the tests locally but they don't work on master.  I think I am probably running them with the wrong rust version or something.)