### PR TITLE
Add new attribute: inhibit_automatic_where_clause

### DIFF
--- a/ambassador/src/delegate_shared.rs
+++ b/ambassador/src/delegate_shared.rs
@@ -22,6 +22,7 @@ pub(super) struct DelegateArgs<T: DelegateTarget> {
     pub(crate) target: T,
     pub(crate) where_clauses: Punctuated<WherePredicate, Comma>,
     pub(crate) generics: Vec<GenericParam>,
+    pub(crate) inhibit_automatic_where_clause: bool,
 }
 
 fn is_comma(tt: &TokenTree) -> bool {
@@ -54,6 +55,9 @@ impl<T: DelegateTarget> DelegateArgs<T> {
                         "generics" => {
                             let generics_val = lit.parse_with(Punctuated::<GenericParam, Comma>::parse_terminated).expect("Invalid syntax for delegate attribute; Expected list of generic parameters as value for \"generics\"");
                             res.generics.extend(generics_val);
+                        }
+                        "inhibit_automatic_where_clause" => {
+                            res.inhibit_automatic_where_clause = true;
                         }
                         key => res.target.try_update(key, lit).unwrap_or_else(|| {
                             panic!("{} is not a valid key for a delegate attribute", key)

--- a/ambassador/src/delegate_shared.rs
+++ b/ambassador/src/delegate_shared.rs
@@ -56,14 +56,14 @@ impl<T: DelegateTarget> DelegateArgs<T> {
                             let generics_val = lit.parse_with(Punctuated::<GenericParam, Comma>::parse_terminated).expect("Invalid syntax for delegate attribute; Expected list of generic parameters as value for \"generics\"");
                             res.generics.extend(generics_val);
                         }
-                        "inhibit_automatic_where_clause" => {
+                        "automatic_where_clause" => {
                             let val = val.to_string();
                             if &val == "\"true\"" {
-                                res.inhibit_automatic_where_clause = true;
-                            } else if &val == "\"false\"" {
                                 res.inhibit_automatic_where_clause = false;
+                            } else if &val == "\"false\"" {
+                                res.inhibit_automatic_where_clause = true;
                             } else {
-                                panic!("inhibit_automatic_where_clause delegate attribute should have value \"true\" or \"false\".")
+                                panic!("automatic_where_clause delegate attribute should have value \"true\" or \"false\".")
                             }
                         }
                         key => res.target.try_update(key, lit).unwrap_or_else(|| {

--- a/ambassador/src/derive.rs
+++ b/ambassador/src/derive.rs
@@ -200,7 +200,9 @@ fn delegate_single_attr(
                         "\"target\" value on #[delegate] attribute can not be specified for enums"
                     );
                 }
-                add_auto_where_clause(&mut where_clause, &trait_path_full, first_type);
+                if !args.inhibit_automatic_where_clause {
+                    add_auto_where_clause(&mut where_clause, &trait_path_full, first_type);
+                }
                 let match_name = match_name(trait_ident);
                 where_clause
                     .predicates
@@ -230,7 +232,9 @@ fn delegate_single_attr(
                 if !matches!(&args.target, DelegateTarget::None) {
                     panic!("\"target\" value on #[delegate] attribute can not be specified for structs with a single field");
                 }
-                add_auto_where_clause(&mut where_clause, &trait_path_full, field_type);
+                if !args.inhibit_automatic_where_clause {
+                    add_auto_where_clause(&mut where_clause, &trait_path_full, field_type);
+                }
 
                 quote! {
                     impl <#(#impl_generics,)*> #trait_path_full for #implementer_ident #ty_generics #where_clause {
@@ -242,7 +246,9 @@ fn delegate_single_attr(
                 let field = args.target.get_field(fields);
                 let field_ident = &field.0;
                 let field_type = &field.1;
-                add_auto_where_clause(&mut where_clause, &trait_path_full, field_type);
+                if !args.inhibit_automatic_where_clause {
+                    add_auto_where_clause(&mut where_clause, &trait_path_full, field_type);
+                }
 
                 quote! {
                     impl <#(#impl_generics,)*> #trait_path_full for #implementer_ident #ty_generics #where_clause {

--- a/ambassador/src/lib.rs
+++ b/ambassador/src/lib.rs
@@ -252,6 +252,42 @@ use crate::register::build_register_trait;
 /// // We could also use #[delegate(Shout<& 'a str>, generics = "'a")] to only delegate for &str
 /// pub struct WrappedCat(Cat);
 /// ```
+/// 
+/// 
+/// #### `#[delegate(Shout, automatic_where_clause = "false")]` - inhibit automatic generation of `where` clause.
+/// 
+/// Normally `#[derive(Delegate)]` generates code to ensure that chosen field indeed implementes  the trait
+/// you want to implement for the container struct.
+/// However, you may want to delegate implementation to something that does not in fact fully implement the trait
+/// in question, instead just have compatible methods that can be called as if the trait were in fact implemented.
+/// 
+/// One notable case of this is implementing `MyTrait` for `Box<dyn MyTrait>` or similar trait object things.
+/// It is not always possible even for object-safe traits, but is often possible.
+/// 
+/// ```
+/// use ambassador::{delegatable_trait, Delegate};
+/// use std::fmt::Display;
+///
+/// #[delegatable_trait]
+/// pub trait Shout {
+///     fn shout(&self, input: &str) -> String;
+/// }
+///
+/// pub struct Cat;
+///
+/// impl Shout for Cat {
+///     fn shout(&self, input: &str) -> String {
+///         format!("{} - meow!", input)
+///     }
+/// }
+///
+/// #[derive(Delegate)]
+/// #[delegate(Shout, automatic_where_clause="false")]
+/// pub struct BoxedAnimal(pub Box<dyn Shout + Send + Sync>);
+/// 
+/// // Can accept both `Cat` and `BoxedAnimal`.
+/// fn recording_studio<S: Shout>(voice_actor: S){}
+/// ```
 #[proc_macro_derive(Delegate, attributes(delegate))]
 pub fn delegate_macro(input: TokenStream) -> TokenStream {
     derive::delegate_macro(input)

--- a/ambassador/src/lib.rs
+++ b/ambassador/src/lib.rs
@@ -252,18 +252,18 @@ use crate::register::build_register_trait;
 /// // We could also use #[delegate(Shout<& 'a str>, generics = "'a")] to only delegate for &str
 /// pub struct WrappedCat(Cat);
 /// ```
-/// 
-/// 
+///
+///
 /// #### `#[delegate(Shout, automatic_where_clause = "false")]` - inhibit automatic generation of `where` clause.
-/// 
+///
 /// Normally `#[derive(Delegate)]` generates code to ensure that chosen field indeed implementes  the trait
 /// you want to implement for the container struct.
 /// However, you may want to delegate implementation to something that does not in fact fully implement the trait
 /// in question, instead just have compatible methods that can be called as if the trait were in fact implemented.
-/// 
+///
 /// One notable case of this is implementing `MyTrait` for `Box<dyn MyTrait>` or similar trait object things.
 /// It is not always possible even for object-safe traits, but is often possible.
-/// 
+///
 /// ```
 /// use ambassador::{delegatable_trait, Delegate};
 /// use std::fmt::Display;
@@ -284,7 +284,7 @@ use crate::register::build_register_trait;
 /// #[derive(Delegate)]
 /// #[delegate(Shout, automatic_where_clause="false")]
 /// pub struct BoxedAnimal(pub Box<dyn Shout + Send + Sync>);
-/// 
+///
 /// // Can accept both `Cat` and `BoxedAnimal`.
 /// fn recording_studio<S: Shout>(voice_actor: S){}
 /// ```

--- a/ambassador/tests/run-pass/delegate_to_methods_dyn_works.rs
+++ b/ambassador/tests/run-pass/delegate_to_methods_dyn_works.rs
@@ -1,0 +1,53 @@
+// Ensure that deletage_to_methods can be used as alternative to inhibit_automatic_where_clause for auto-deriving traits for objects.
+
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, delegate_to_methods};
+
+#[delegatable_trait]
+pub trait Shout {
+    fn shout(&self, input: &str) -> String;
+}
+
+pub struct Cat;
+
+impl Shout for Cat {
+    fn shout(&self, input: &str) -> String {
+        format!("{} - meow!", input)
+    }
+}
+
+pub struct Dog;
+
+impl Shout for Dog {
+    fn shout(&self, input: &str) -> String {
+        format!("{} - wuff!", input)
+    }
+}
+
+pub struct WrappedAnimals(pub Box<dyn Shout>);
+
+
+#[delegate_to_methods]
+#[delegate(Shout, target_ref="deref")]
+impl WrappedAnimals {
+    // Note that ` &dyn Shout` itself does not implement `Shout`,
+    // but for this particular trait all `Shout`'s methods can still be called.
+    // If Ambassador were to insert `where &dyn Shout : Shout` clause based on method return value,
+    // that whould stop working, breaking backwards compatiblity.
+    //
+    // Such where clause can be generated, but then `inhibit_automatic_where_clause` needs to
+    // be implemented for `delegate_to_methods` as well.  
+    fn deref(&self) -> &dyn Shout {
+        &*self.0
+    }
+}
+
+fn use_it<T: Shout> (shouter: T) {
+    println!("{}", shouter.shout("BAR"));
+}
+
+pub fn main() {
+    let foo_animal = WrappedAnimals(Box::new(Cat));
+    use_it(foo_animal);
+}

--- a/ambassador/tests/run-pass/inhibit_where_clause.rs
+++ b/ambassador/tests/run-pass/inhibit_where_clause.rs
@@ -1,0 +1,38 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, Delegate};
+
+#[delegatable_trait]
+pub trait Shout {
+    fn shout(&self, input: &str) -> String;
+}
+
+pub struct Cat;
+
+impl Shout for Cat {
+    fn shout(&self, input: &str) -> String {
+        format!("{} - meow!", input)
+    }
+}
+
+pub struct Dog;
+
+impl Shout for Dog {
+    fn shout(&self, input: &str) -> String {
+        format!("{} - wuff!", input)
+    }
+}
+
+#[derive(Delegate)]
+#[delegate(Shout,inhibit_automatic_where_clause="true")]
+pub struct WrappedAnimals(pub Box<dyn Shout>);
+
+
+fn use_it<T: Shout> (shouter: T) {
+    println!("{}", shouter.shout("BAR"));
+}
+
+pub fn main() {
+    let foo_animal = WrappedAnimals(Box::new(Cat));
+    use_it(foo_animal);
+}

--- a/ambassador/tests/run-pass/inhibit_where_clause.rs
+++ b/ambassador/tests/run-pass/inhibit_where_clause.rs
@@ -24,7 +24,7 @@ impl Shout for Dog {
 }
 
 #[derive(Delegate)]
-#[delegate(Shout,inhibit_automatic_where_clause="true")]
+#[delegate(Shout,automatic_where_clause="false")]
 pub struct WrappedAnimals(pub Box<dyn Shout>);
 
 


### PR DESCRIPTION
Allows to opt out of where clause, in cases where it gets in the way.

My use case:

```rust

#[delegatable_trait]
trait SomeTrait{}

#[derive(ambassador::Delegate)]
#[delegate(SomeTrait,inhibit_automatic_where_clause="true")]
pub struct DynSomeTrait(pub Box<dyn SomeTrait + Send>);
```

It allows user to request structural typing (like with `target="self"`), but with other targets instead of `self`.

If this feature is welcome in `ambassador`, I can also provide in this pull request:

* Similar attribute for impl delegation
* Documentation
* Test