### PR TITLE
Add a `delegate_to_remote_methods` macro

### DIFF
--- a/ambassador/Cargo.toml
+++ b/ambassador/Cargo.toml
@@ -23,7 +23,7 @@ proc-macro2 = "1.0.6"
 itertools = "0.10.3"
 
 [dev-dependencies]
-compiletest_rs = { version = "0.3.25", features = [ "stable" ]}
+compiletest_rs = "0.8"
 
 [package.metadata.release]
 no-dev-version = true

--- a/ambassador/src/delegate_shared.rs
+++ b/ambassador/src/delegate_shared.rs
@@ -32,9 +32,9 @@ fn is_comma(tt: &TokenTree) -> bool {
 
 const INVALID_MSG: &str = "Invalid syntax for delegate attribute";
 
-pub(super) fn delegate_attr_as_trait_and_iter(tokens: TokenStream2)
-    -> (syn::Path, impl Iterator<Item = (String, LitStr)>)
-{
+pub(super) fn delegate_attr_as_trait_and_iter(
+    tokens: TokenStream2,
+) -> (syn::Path, impl Iterator<Item = (String, LitStr)>) {
     let mut outer_iter = tokens.into_iter();
     let mut iter = match outer_iter.next() {
         Some(TokenTree::Group(g)) => g.stream().into_iter(),
@@ -77,7 +77,7 @@ pub(super) fn delegate_attr_as_trait_and_iter(tokens: TokenStream2)
                     // encountered fewer than three trailing tokens and not that
                     // we've actually run out of tokens:
                     panic!("{} (extra trailing tokens)", INVALID_MSG);
-                },
+                }
             }
         }
     });

--- a/ambassador/src/delegate_to_methods.rs
+++ b/ambassador/src/delegate_to_methods.rs
@@ -5,11 +5,11 @@ use crate::util::ReceiverType;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
-use syn::spanned::Spanned;
+use std::collections::HashSet;
 use std::convert::{TryFrom, TryInto};
 use std::default::Default;
-use std::collections::HashSet;
 use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
 use syn::{
     parse_macro_input, GenericParam, ItemImpl, LitStr, ReturnType, Token, Type, WhereClause,
 };
@@ -133,7 +133,8 @@ fn search_methods<'a>(
 impl DelegateTarget {
     /// Select the correct return.
     pub fn get_ret_type<'a>(&self, methods: &'a [MethodInfo]) -> &'a Type {
-        let res = self.as_arr()
+        let res = self
+            .as_arr()
             .iter()
             .flat_map(|(recv_ty, id)| search_methods(*id, methods, *recv_ty))
             .fold(None, |rsf, x| match rsf {
@@ -161,13 +162,16 @@ fn check_for_method_impls_and_extras(
 
         for delegate_attr in attrs {
             let mut delegate_target = DelegateTarget::default();
-            for (k, v) in delegate_shared::delegate_attr_as_trait_and_iter(delegate_attr.tokens.clone()).1 {
+            for (k, v) in
+                delegate_shared::delegate_attr_as_trait_and_iter(delegate_attr.tokens.clone()).1
+            {
                 let _ = delegate_target.try_update(&*k, v);
 
-                hs.extend(delegate_target
-                    .as_arr()
-                    .iter()
-                    .filter_map(|(_, func_name)| func_name.cloned())
+                hs.extend(
+                    delegate_target
+                        .as_arr()
+                        .iter()
+                        .filter_map(|(_, func_name)| func_name.cloned()),
                 );
             }
         }

--- a/ambassador/src/delegate_to_methods.rs
+++ b/ambassador/src/delegate_to_methods.rs
@@ -5,8 +5,10 @@ use crate::util::ReceiverType;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
+use syn::spanned::Spanned;
 use std::convert::{TryFrom, TryInto};
 use std::default::Default;
+use std::collections::HashSet;
 use syn::punctuated::Punctuated;
 use syn::{
     parse_macro_input, GenericParam, ItemImpl, LitStr, ReturnType, Token, Type, WhereClause,
@@ -95,6 +97,17 @@ impl delegate_shared::DelegateTarget for DelegateTarget {
     }
 }
 
+impl DelegateTarget {
+    fn as_arr(&self) -> [(ReceiverType, Option<&Ident>); 3] {
+        use ReceiverType::*;
+        [
+            (Owned, self.owned_id.as_ref()),
+            (Ref, self.ref_id.as_ref()),
+            (MutRef, self.ref_mut_id.as_ref()),
+        ]
+    }
+}
+
 type DelegateArgs = delegate_shared::DelegateArgs<DelegateTarget>;
 
 fn search_methods<'a>(
@@ -120,11 +133,9 @@ fn search_methods<'a>(
 impl DelegateTarget {
     /// Select the correct return.
     pub fn get_ret_type<'a>(&self, methods: &'a [MethodInfo]) -> &'a Type {
-        let owned_ty = search_methods(self.owned_id.as_ref(), methods, ReceiverType::Owned);
-        let ref_ty = search_methods(self.ref_id.as_ref(), methods, ReceiverType::Ref);
-        let ref_mut_ty = search_methods(self.ref_mut_id.as_ref(), methods, ReceiverType::MutRef);
-        let res = IntoIterator::into_iter([owned_ty, ref_ty, ref_mut_ty])
-            .flatten()
+        let res = self.as_arr()
+            .iter()
+            .flat_map(|(recv_ty, id)| search_methods(*id, methods, *recv_ty))
             .fold(None, |rsf, x| match rsf {
                 None => Some(x),
                 Some(y) if y == x => Some(x),
@@ -132,6 +143,77 @@ impl DelegateTarget {
             });
 
         res.unwrap_or_else(|| panic!("no targets were specified"))
+    }
+}
+
+// Checks that:
+//   - all the items in an impl are methods
+//   - all the methods are _empty_ (no body, just the signature)
+//   - all the methods provided are actually referenced in the `delegate` attributes on the impl
+fn check_for_method_impls_and_extras(
+    attrs: &[syn::Attribute],
+    impl_items: &[syn::ImplItem],
+) -> Result<(), syn::Error> {
+    use delegate_shared::DelegateTarget as _;
+
+    let referenced_target_methods = {
+        let mut hs: HashSet<syn::Ident> = HashSet::new();
+
+        for delegate_attr in attrs {
+            let mut delegate_target = DelegateTarget::default();
+            for (k, v) in delegate_shared::delegate_attr_as_trait_and_iter(delegate_attr.tokens.clone()).1 {
+                let _ = delegate_target.try_update(&*k, v);
+
+                hs.extend(delegate_target
+                    .as_arr()
+                    .iter()
+                    .filter_map(|(_, func_name)| func_name.cloned())
+                );
+            }
+        }
+
+        hs
+    };
+
+    let error_message = impl_items.iter()
+        .filter_map(|i| {
+            // We're looking for *only* empty methods (no block).
+            if let syn::ImplItem::Method(m) = i {
+                let block = &m.block;
+                let empty_block = syn::parse2::<syn::ImplItemMethod>(quote!{ fn foo(); })
+                    .unwrap().block;
+
+                // We'll accept `{}` blocks and omitted blocks (i.e. `fn foo();`):
+                if block.stmts.is_empty() || block == &empty_block {
+                    // Provided that they're actually referenced by a
+                    // `delegate(...)` attr on this impl:
+                    if referenced_target_methods.contains(&m.sig.ident) {
+                        None
+                    } else {
+                        Some(syn::Error::new(m.span(), "This method is not used by any `delegate` attributes; please remove it"))
+                    }
+                } else {
+                    Some(syn::Error::new(block.span(), "Only method signatures are allowed here (no blocks!)"))
+                }
+            } else {
+                // Everything else is an error:
+                Some(syn::Error::new(i.span(), "Only method signatures are allowed here, everything else is discarded"))
+            }
+        })
+        .fold(None, |errors, error| {
+            match (errors, error) {
+                (None, err) => Some(err),
+                (Some(mut errs), err) => {
+                    errs.extend(err);
+                    Some(errs)
+                },
+            }
+        });
+
+    if let Some(err) = error_message {
+        Err(err)
+    } else {
+        Ok(())
     }
 }
 
@@ -146,6 +228,10 @@ pub fn delegate_macro(input: TokenStream, keep_impl_block: bool) -> TokenStream 
     let input_copy = if keep_impl_block {
         Some(input.to_token_stream())
     } else {
+        if let Err(e) = check_for_method_impls_and_extras(&attrs, &input.items) {
+            return e.into_compile_error().into();
+        }
+
         None
     };
     let implementer = DelegateImplementer {

--- a/ambassador/src/lib.rs
+++ b/ambassador/src/lib.rs
@@ -471,6 +471,11 @@ pub fn delegate_to_methods(_attr: TokenStream, input: TokenStream) -> TokenStrea
     delegate_to_methods::delegate_macro(input, true)
 }
 
+#[proc_macro_attribute]
+pub fn delegate_to_remote_methods(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    delegate_to_methods::delegate_macro(input, false)
+}
+
 /// Make an existing type that lives outside you crate delegate traits to it's members
 ///
 /// This can be done by copy-pasting it's definition into your code under this attribute.

--- a/ambassador/tests/compile-fail/extra_args_in_delegate_attr.rs
+++ b/ambassador/tests/compile-fail/extra_args_in_delegate_attr.rs
@@ -1,0 +1,21 @@
+extern crate ambassador;
+use ambassador::{delegatable_trait, Delegate};
+
+#[delegatable_trait]
+pub trait Shout {
+    fn shout(self) -> String;
+}
+
+pub struct Cat;
+
+impl Shout for Cat {
+    fn shout(self) -> String {
+        "meow!".to_owned()
+    }
+}
+
+#[derive(Delegate)] //~ ERROR proc-macro derive panicked
+#[delegate(Shout, whoops = )]
+pub struct Boxed(Cat);
+
+pub fn main() { }

--- a/ambassador/tests/compile-fail/extra_items_in_remote_methods_impl.rs
+++ b/ambassador/tests/compile-fail/extra_items_in_remote_methods_impl.rs
@@ -1,0 +1,36 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, delegate_to_remote_methods};
+use std::ops::DerefMut;
+
+#[delegatable_trait]
+trait MyTrait {
+    fn get(&self) -> u32;
+    fn change(&mut self);
+}
+
+impl MyTrait for u32 {
+    fn get(&self) -> u32 { *self }
+    fn change(&mut self) { *self += 1 }
+}
+
+#[delegate_to_remote_methods]
+#[delegate(MyTrait, target_ref = "deref", target_mut = "deref_mut")]
+impl<X: ?Sized + MyTrait> Box<X> {
+    fn deref(&self) -> &X;
+    fn deref_mut(&mut self) -> &mut X;
+
+    fn unused_signature(&self); //~ ERROR This method is not used by any `delegate` attributes; please remove it
+
+    fn method_with_body(&mut self) -> &mut X {
+        todo!()
+    } //~^^ ERROR Only method signatures are allowed here (no blocks!)
+
+    const ASSOCIATED_CONST: () = ();
+    //~^ ERROR Only method signatures are allowed here, everything else is discarded
+
+    type SomeType = u8;
+    //~^ ERROR Only method signatures are allowed here, everything else is discarded
+}
+
+fn main() { }

--- a/ambassador/tests/run-pass/delegate_to_methods_in_trait_impl.rs
+++ b/ambassador/tests/run-pass/delegate_to_methods_in_trait_impl.rs
@@ -1,0 +1,44 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, delegate_to_methods};
+use std::ops::DerefMut;
+
+#[delegatable_trait]
+trait MyTrait {
+    fn get(&self) -> u32;
+    fn change(&mut self);
+}
+
+impl MyTrait for u32 {
+    fn get(&self) -> u32 {
+        *self
+    }
+
+    fn change(&mut self) {
+        *self += 1
+    }
+}
+
+struct Wrap<X>(X);
+
+trait HasAU32 {
+    fn get_ref(&self) -> &u32;
+    fn get_mut_ref(&mut self) -> &mut u32;
+}
+
+#[delegate_to_methods]
+#[delegate(MyTrait, target_ref = "get_ref", target_mut = "get_mut_ref")]
+impl<X> HasAU32 for Wrap<X>
+where
+    X: DerefMut<Target = u32>,
+{
+    fn get_ref(&self) -> &u32 { self.0.deref() }
+    fn get_mut_ref(&mut self) -> &mut u32 { self.0.deref_mut() }
+}
+
+fn main() {
+    let mut x = Wrap(Box::new(42u32));
+    assert_eq!(x.get(), 42);
+    x.change();
+    assert_eq!(x.get(), 43);
+}

--- a/ambassador/tests/run-pass/delegate_to_remote_methods.rs
+++ b/ambassador/tests/run-pass/delegate_to_remote_methods.rs
@@ -1,0 +1,46 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, delegate_to_remote_methods};
+use std::ops::{Deref, DerefMut};
+
+#[delegatable_trait]
+trait MyTrait {
+    fn get(&self) -> u32;
+    fn change(&mut self);
+}
+
+impl MyTrait for u32 {
+    fn get(&self) -> u32 {
+        *self
+    }
+
+    fn change(&mut self) {
+        *self += 1
+    }
+}
+
+struct Wrap<X>(X);
+
+trait HasAU32 {
+    fn get_ref(&self) -> &u32;
+    fn get_mut_ref(&mut self) -> &mut u32;
+}
+
+impl<X: DerefMut<Target = u32>> HasAU32 for Wrap<X> {
+    fn get_ref(&self) -> &u32 { self.0.deref() }
+    fn get_mut_ref(&mut self) -> &mut u32 { self.0.deref_mut() }
+}
+
+#[delegate_to_remote_methods]
+#[delegate(MyTrait, target_ref = "get_ref", target_mut = "get_mut_ref")]
+impl<X: DerefMut<Target = u32>> Wrap<X> {
+    fn get_ref(&self) -> &u32;
+    fn get_mut_ref(&mut self) -> &mut u32;
+}
+
+fn main() {
+    let mut x = Wrap(Box::new(42u32));
+    assert_eq!(x.get(), 42);
+    x.change();
+    assert_eq!(x.get(), 43);
+}

--- a/ambassador/tests/run-pass/delegate_to_remote_methods_on_remote_type.rs
+++ b/ambassador/tests/run-pass/delegate_to_remote_methods_on_remote_type.rs
@@ -1,0 +1,34 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, delegate_to_remote_methods};
+use std::ops::{Deref, DerefMut};
+
+#[delegatable_trait]
+trait MyTrait {
+    fn get(&self) -> u32;
+    fn change(&mut self);
+}
+
+impl MyTrait for u32 {
+    fn get(&self) -> u32 { *self }
+    fn change(&mut self) { *self += 1 }
+}
+
+#[delegate_to_remote_methods]
+#[delegate(MyTrait, target_ref = "deref", target_mut = "deref_mut")]
+impl<X: ?Sized + MyTrait> Box<X> {
+    fn deref(&self) -> &X;
+    fn deref_mut(&mut self) -> &mut X;
+}
+
+fn main() {
+    let mut x = Box::new(42u32);
+    assert_eq!(x.get(), 42);
+    x.change();
+    assert_eq!(x.get(), 43);
+
+    let mut y: Box<dyn MyTrait> = x;
+    assert_eq!(y.get(), 43);
+    y.change();
+    assert_eq!(y.get(), 44);
+}


### PR DESCRIPTION
### `delegate_to_remote_methods`

This PR adds `delegate_to_remote_methods`:

```rust
use ambassador::{delegate_to_remote_methods, delegatable_trait};

#[delegatable_trait]
pub trait Shout {
    fn shout(&self, input: &str) -> String;
}

pub struct Cat;

impl Shout for Cat {
    fn shout(&self, input: &str) -> String {
        format!("{} - meow!", input)
    }
}

pub struct BoxedCat(Box<Cat>);

impl BoxedCat {
fn inner(&self) -> &Cat { &self.0 }
}

#[delegate_to_remote_methods]
#[delegate(Shout, target_ref = "inner")]
impl BoxedCat {
    // `inner` can be defined anywhere: trait method or inherent method, in this crate or elsewhere
    fn inner(&self) -> &Cat;
}
```

It's identical to `delegate_to_methods` except:
  - it does not preserve the `impl` block it is applied to in its output
  - it checks that there are no method bodies or unused items in the impl block it is applied to

This allows it to be used in scenarios involving foreign `Self` types (without needing to create intermediary local traits to house the target methods) like the one described in #36:
```rust
use ambassador::{delegatable_trait, delegate_to_remote_methods};
use std::ops::{Deref, DerefMut};
use std::{sync::Arc, rc::Rc};

#[delegatable_trait]
pub trait Shout { fn shout(&self, input: &str) -> String; }

pub struct Cat;
impl Shout for Cat { fn shout(&self, input: &str) -> String { format!("{} - meow!", input) } }

pub struct Dog;
impl Shout for Dog { fn shout(&self, input: &str) -> String { format!("{} - wuff!", input) } }

#[delegate_to_remote_methods]
#[delegate(Shout, target_ref = "deref")]
impl<S: ?Sized + Send + Shout, T: Deref<Target = S>> T {
    fn deref(&self) -> &S;
}

pub fn shout(pet: &impl Shout) { println!("{}", pet.shout("hi")); }

pub fn main() {
    shout(&Cat);
    shout(&Dog);

    let a: Box<dyn Shout> = Box::new(Cat);
    let b: Arc<dyn Shout + Send> = Arc::new(Dog);
    let c: Rc<dyn Shout + Send + Sync + 'static> = Rc::new(Cat);
    // shout(&a); // Will error since we required `Send` above.
    shout(&b);
    shout(&c);

    let d: Box<Cat> = Box::new(Cat);
    shout(&d);
}
```

---

### Other Stuff

There are a couple of other things in this PR:
  - tests and updates to the docs clarifying that `#[delegate_to_methods] impl Trait for Type { ... }` is permitted
  - some miscellaneous [fixes](https://github.com/hobofan/ambassador/pull/34/files#diff-f1d078c3e148d19a358b428ea78772fe6df80b0769e138d0f5be1b608461f296R78-R80) and tests for the `delegate(...)` attr parsing logic

I can split these into their own PRs if required.

### Open Questions

Is the name okay? `delegate_to_remote_methods` mirrors `delegate_remote` (which makes sense since, like `delegate_remote` does not require the type the impls are on to be local, this macro relaxes the requirement that the methods used to do the delegation be local) but it's perhaps misleading since `delegate_to_remote_methods` will also accept a remote type (as will `delegate_to_methods` if you place it on a block that implements a trait).

Currently the macro is pretty aggressive about checking that there aren't extra/unused items in the `impl` it is applied to; my thinking was that silently dropping these items could be a source of confusion. Do we want to relax these checks?
