### PR TITLE
Added support for GATs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable # It's useful to test applications of these macros to newer features so a 1.53 test doesn't work
+          - beta # It's useful to test applications of these macros to newer features so a 1.53 test doesn't work (beta to test GATs)
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/ambassador/src/register.rs
+++ b/ambassador/src/register.rs
@@ -234,10 +234,9 @@ fn build_trait_items(
         TraitItem::Type(TraitItemType {
             ident, generics, ..
         }) => {
-            let _where_clause = &generics.where_clause;
+            let where_clause = &generics.where_clause;
             let item = quote! {
-                type #ident #generics = <$ty as #trait_ident<#gen_pat>>::#ident #generics;
-                // TODO add #where_clase to appropriate place once it is decided
+                type #ident #generics = <$ty as #trait_ident<#gen_pat>>::#ident #generics #where_clause;
             };
             (
                 item.clone(),

--- a/ambassador/tests/run-pass/gat.rs
+++ b/ambassador/tests/run-pass/gat.rs
@@ -1,0 +1,32 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, Delegate};
+
+#[delegatable_trait]
+pub trait StreamingIterator {
+    type Output<'a>
+    where
+        Self: 'a;
+    fn next(&mut self) -> Option<Self::Output<'_>>;
+}
+
+struct RepeatMut<T>(T);
+
+impl<T> StreamingIterator for RepeatMut<T> {
+    type Output<'a> = &'a mut T where T: 'a;
+
+    fn next(&mut self) -> Option<Self::Output<'_>> {
+        Some(&mut self.0)
+    }
+}
+
+#[derive(Delegate)]
+#[delegate(StreamingIterator)]
+pub struct Wrap<X>(X);
+
+pub fn main() {
+    let mut x = Wrap(RepeatMut("forever".into()));
+    let m: &mut String = x.next().unwrap();
+    m.push('?');
+    assert_eq!(x.next().unwrap(), "forever?");
+}


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/issues/89122 was decided we can now enable delegating to traits that use GATs (other than enums).
This also sets the CI to test with beta, which can probably be reverted once GATs are stable