### PR TITLE
Forward type parameters

### DIFF
--- a/ambassador/src/register.rs
+++ b/ambassador/src/register.rs
@@ -312,6 +312,9 @@ fn build_method_invocation(
         })
         .collect();
 
-    let method_invocation = quote! { #field_ident.#method_ident(#argument_list) };
+    let generics = method_sig.generics.split_for_impl().1;
+    let turbofish = generics.as_turbofish();
+
+    let method_invocation = quote! { #field_ident.#method_ident #turbofish(#argument_list) };
     method_invocation
 }

--- a/ambassador/tests/run-pass/generic_method.rs
+++ b/ambassador/tests/run-pass/generic_method.rs
@@ -1,0 +1,46 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, Delegate};
+
+trait StaticFn {
+    fn call() -> bool;
+}
+
+struct StaticTrue;
+struct StaticFalse;
+
+impl StaticFn for StaticTrue {
+    fn call() -> bool {
+        true
+    }
+}
+
+impl StaticFn for StaticFalse {
+    fn call() -> bool {
+        false
+    }
+}
+
+#[delegatable_trait]
+pub trait StaticCall {
+    fn call<C: StaticFn>(&self) -> bool;
+}
+
+pub struct BaseCaller;
+
+impl StaticCall for BaseCaller {
+    fn call<C: StaticFn>(&self) -> bool {
+        C::call()
+    }
+}
+
+#[derive(Delegate)]
+#[delegate(StaticCall)]
+pub struct WrappedCaller(BaseCaller);
+
+fn main() {
+    let c = WrappedCaller(BaseCaller);
+    // Verify that the generic type is correctly passed through without relying on type inference.
+    assert!(c.call::<StaticTrue>());
+    assert!(!c.call::<StaticFalse>());
+}


### PR DESCRIPTION
Forward type parameters (and lifetimes, consts, etc.) in delegated calls as we can't always rely on type inference infering the correct ones from the context.