### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,16 +8,21 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
           - 1.53.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: nightly
+          override: false
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
       - run: rustup component add rustfmt
+      - run: cargo +nightly update -Z minimal-versions
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -29,16 +34,21 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
           - 1.53.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: nightly
+          override: false
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
       - run: rustup component add clippy
+      - run: cargo +nightly update -Z minimal-versions
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ name: Check & Test
 
 jobs:
   check:
-    name: Clippy
+    name: Check
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,10 @@ jobs:
     strategy:
       matrix:
         rust:
-          - beta # It's useful to test applications of these macros to newer features so a 1.53 test doesn't work (beta to test GATs)
+          - 1.75.0
+          # It's useful to test applications of these macros to newer features so using 1.53 for tests doesn't work
+          # This needs to be locked to a specific version of Rust since the exact error messages may change
+          # When switching this Rust version make sure to also update tests to use newer error messages if applicable
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,20 +4,25 @@ name: Check & Test
 
 jobs:
   check:
-    name: Check
+    name: Clippy
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - stable
           - 1.53.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: nightly
+          override: false
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - run: cargo +nightly update -Z minimal-versions
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/ambassador/Cargo.toml
+++ b/ambassador/Cargo.toml
@@ -17,7 +17,7 @@ default = ["backward_compatible"]
 backward_compatible = []
 
 [dependencies]
-syn = { version = "1.0.8", features = ["full", "extra-traits"] }
+syn = { version = "1.0.25", features = ["full", "extra-traits"] }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 itertools = "0.10.3"

--- a/ambassador/src/delegate_shared.rs
+++ b/ambassador/src/delegate_shared.rs
@@ -9,8 +9,8 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{
-    parse_quote, Error, GenericParam, Generics, ImplGenerics, LitBool, LitStr, PathArguments,
-    Result, Token, WhereClause, WherePredicate,
+    parse_quote, GenericParam, Generics, ImplGenerics, LitBool, LitStr, PathArguments, Result,
+    Token, WhereClause, WherePredicate,
 };
 
 pub(super) trait DelegateTarget: Default {
@@ -97,14 +97,14 @@ pub(super) fn delegate_macro<I>(
         return error!(
             proc_macro2::Span::call_site(),
             "No #[delegate] attribute specified. If you want to delegate an implementation of trait `SomeTrait` add the attribute:\n#[delegate(SomeTrait)]"
-        ).unwrap_or_else(Error::into_compile_error);
+        ).unwrap_or_else(|x| x.to_compile_error());
     }
 
     let iter = delegate_attributes
         .into_iter()
         .map(|attr| delegate_single(input, attr));
     let res = process_results(iter, |iter| iter.flatten().collect());
-    res.unwrap_or_else(Error::into_compile_error)
+    res.unwrap_or_else(|x| x.to_compile_error())
 }
 
 pub(super) fn trait_info(trait_path_full: &syn::Path) -> Result<(&Ident, impl ToTokens + '_)> {

--- a/ambassador/src/delegate_to_methods.rs
+++ b/ambassador/src/delegate_to_methods.rs
@@ -288,7 +288,7 @@ pub fn delegate_macro(input: TokenStream, keep_impl_block: bool) -> TokenStream 
             let invalid_err_iter = implementer.invalid_methods.into_iter().map(|(_, err)| err);
             let invalid_err = fold_errors(unused_err, invalid_err_iter);
             if let Err(err) = invalid_err {
-                res.extend(err.into_compile_error());
+                res.extend(err.to_compile_error());
             }
         }
     }

--- a/ambassador/src/derive.rs
+++ b/ambassador/src/derive.rs
@@ -146,7 +146,7 @@ pub fn delegate_macro(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let info = match try_info_from_data(input.span(), input.data) {
         Ok(info) => info,
-        Err(err) => return err.into_compile_error().into(),
+        Err(err) => return err.to_compile_error().into(),
     };
     let implementer = DelegateImplementer {
         info,

--- a/ambassador/src/register.rs
+++ b/ambassador/src/register.rs
@@ -50,7 +50,7 @@ pub fn build_register_trait(original_item: &ItemTrait) -> TokenStream {
     let (struct_items, enum_items, self_items): (Vec<_>, Vec<_>, Vec<_>) =
         match process_results(iter, |iter| iter.multiunzip()) {
             Ok(tup) => tup,
-            Err(err) => return err.into_compile_error(),
+            Err(err) => return err.to_compile_error(),
         };
     let assoc_ty_bounds = make_assoc_ty_bound(&original_item.items, original_item, &match_name);
     let gen_idents_pat: TokenStream = gen_idents.into_iter().map(|id| quote! {$ #id ,}).collect();

--- a/ambassador/tests/compile-fail/enum_associated_constant.rs
+++ b/ambassador/tests/compile-fail/enum_associated_constant.rs
@@ -27,7 +27,5 @@ pub enum Pet {
 }
 
 fn main() {
-    println!("{}", Pet::NUM_LEGS) //~ ERROR erroneous constant used [const_err]
-                                  //~^ WARNING this was previously accepted by the compiler but is being phased out
-                                  //~^^ Error evaluation of constant value failed [E0080]
+    println!("{}", Pet::NUM_LEGS)
 }


### PR DESCRIPTION
The previous CI setup was very fragile to external changes (eg. new versions of Rust). This hopefully improves things by running MSRV tests using minimal dependency versions, and freezing the Rust version used for the test suite.

CI also doesn't seem to be running on hobofan/ambassador at all so we'll see if this starts it.