### PR TITLE
Switch tests to use rust 1.79.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.75.0
+          - 1.79.0
           # It's useful to test applications of these macros to newer features so using 1.53 for tests doesn't work
           # This needs to be locked to a specific version of Rust since the exact error messages may change
           # When switching this Rust version make sure to also update tests to use newer error messages if applicable

--- a/ambassador/tests/compile-fail/delegate_to_missing_method.rs
+++ b/ambassador/tests/compile-fail/delegate_to_missing_method.rs
@@ -4,7 +4,6 @@ use ambassador::{delegatable_trait, delegate_to_methods};
 use std::ops::DerefMut;
 
 #[delegatable_trait] //~ ERROR target_owned was not specified but was needed
-                     //~^ ERROR unexpected token: `.`
 trait MyTrait {
     fn get(&self) -> u32;
     fn change(&mut self);

--- a/ambassador/tests/compile-fail/generic_trait_bad_where.rs
+++ b/ambassador/tests/compile-fail/generic_trait_bad_where.rs
@@ -21,7 +21,7 @@ fn main() {
     let m1 = SomeMap::Hash(HashMap::from([("dog".to_string(), "wuff")]));
     let m2 = SomeMap::BTree(BTreeMap::from([("cat".to_string(), "meow")]));
     assert_eq!(m1["dog"], "wuff");
-    //~^ ERROR the trait bound `u32: From<&_>` is not satisfied
+    //~^ ERROR the trait bound `&_: Into<u32>` is not satisfied
     assert_eq!(m2["cat"], "meow");
-    //~^ ERROR the trait bound `u32: From<&_>` is not satisfied
+    //~^ ERROR the trait bound `&_: Into<u32>` is not satisfied
 }


### PR DESCRIPTION
Also fix warning produced when using `delegate_to_method`s and not specifying a required target.