### PR TITLE
Support impl Future enum delegation

### DIFF
--- a/ambassador/tests/run-pass/async_associated_enum.rs
+++ b/ambassador/tests/run-pass/async_associated_enum.rs
@@ -1,0 +1,41 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, Delegate};
+
+#[delegatable_trait]
+pub trait Hello {
+    type Error;
+
+    async fn hello(&self) -> Result<(), Self::Error>;
+    fn bye(&self) -> impl ::core::future::Future<Output = Result<(), Self::Error>> + Send;
+}
+
+pub struct Base1 {}
+impl Hello for Base1 {
+    type Error = ();
+    async fn hello(&self) -> Result<(), ()> {
+        Ok(())
+    }
+    fn bye(&self) -> impl ::core::future::Future<Output = Result<(), Self::Error>> + Send {
+        async { Ok(()) }
+    }
+}
+pub struct Base2 {}
+impl Hello for Base2 {
+    type Error = ();
+    async fn hello(&self) -> Result<(), ()> {
+        Ok(())
+    }
+    fn bye(&self) -> impl ::core::future::Future<Output = Result<(), Self::Error>> + Send {
+        async { Ok(()) }
+    }
+}
+
+#[derive(Delegate)]
+#[delegate(Hello)]
+pub enum Either {
+    Base1(Base1),
+    Base2(Base2),
+}
+
+pub fn main() {}

--- a/ambassador/tests/run-pass/impl_future_enum.rs
+++ b/ambassador/tests/run-pass/impl_future_enum.rs
@@ -38,4 +38,10 @@ pub enum Either {
     Base2(Base2),
 }
 
+#[derive(Delegate)]
+#[delegate(Hello)]
+pub struct One {
+    base: Base1,
+}
+
 pub fn main() {}


### PR DESCRIPTION
In some cases, `async fn` in public traits are not recommended as you cannot add bounds like `Send` to the desugared future.  The recommended approach is to write out the future directly (or use [trait-variant](https://crates.io/crates/trait-variant)):

```rs
fn bye(&self) -> impl ::core::future::Future<Output = Result<(), Self::Error>> + Send {
    async { Ok(()) }
}
```

However, when using enum delegation, the autogen code looks like this:
```rs
fn bye(
    &self,
) -> impl ::core::future::Future<Output = Result<(), Self::Error>> + Send {
    match self {
        Either::Base1(inner) => inner.bye(),
        Either::Base2(inner) => inner.bye(),
    }
}
```

This results in the error 

```
`match` arms have incompatible types
   distinct uses of `impl Trait` result in different opaque types [E0308]
   test2.rs:71:9: Error originated from macro call here
   test2.rs:71:9: Error originated from macro call here
   test2.rs:59:21: the expected future
   test2.rs:66:21: the found future
   test2.rs:53:21: you could change the return type to be a boxed trait object: `Box<dyn`, `>`
   test2.rs:50:0: if you change the return type to expect trait objects, box the returned expressions: `Box::new(`, `)`
2. if you change the return type to expect trait objects, box the returned expressions: `Box::new(`, `)` [E0308]
   test2.rs:50:0: original diagnostic
```

This is because each branch implements a different future.

The solution is to wrap the match in an async block:

```rs
fn bye(
    &self,
) -> impl ::core::future::Future<Output = Result<(), Self::Error>> + Send {
    async move {
        match self {
            Either::Base1(inner) => inner.bye().await,
            Either::Base2(inner) => inner.bye().await,
        }
    }
}
```

This PR automatically adds the async block for enum delegation that returns impl Future.
