### PR TITLE
Explicitly specify traits in generated code to support methods with the same name

### DIFF
--- a/ambassador/Cargo.toml
+++ b/ambassador/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ambassador"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Maximilian Goisser <goisser94@gmail.com>", "David Ewert <dewert10@gmail.com>"]
 edition = "2018"
 description = "Trait implementation delegation via procedural macros"

--- a/ambassador/tests/run-pass/delegate_to_deref.rs
+++ b/ambassador/tests/run-pass/delegate_to_deref.rs
@@ -1,0 +1,41 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, delegate_to_remote_methods, Delegate};
+
+#[delegatable_trait]
+pub trait Shout {
+    fn shout(&self, input: &str) -> String;
+}
+
+pub struct Cat;
+
+impl Shout for Cat {
+    fn shout(&self, input: &str) -> String {
+        format!("{} - meow!", input)
+    }
+}
+
+pub struct Dog;
+
+impl Shout for Dog {
+    fn shout(&self, input: &str) -> String {
+        format!("{} - wuff!", input)
+    }
+}
+
+#[delegate_to_remote_methods]
+#[delegate(Shout, target_ref = "deref")]
+impl<T: ?Sized> Box<T> {}
+
+#[derive(Delegate)]
+#[delegate(Shout)]
+pub struct WrappedAnimals(pub Box<dyn Shout>);
+
+fn use_it<T: Shout>(shouter: T) {
+    println!("{}", shouter.shout("BAR"));
+}
+
+pub fn main() {
+    let foo_animal = WrappedAnimals(Box::new(Cat));
+    use_it(foo_animal);
+}

--- a/ambassador/tests/run-pass/delegate_to_deref2.rs
+++ b/ambassador/tests/run-pass/delegate_to_deref2.rs
@@ -1,10 +1,17 @@
 extern crate ambassador;
 
-use ambassador::{delegatable_trait, Delegate};
+use ambassador::{delegatable_trait, delegate_to_remote_methods, Delegate};
 
 #[delegatable_trait]
 pub trait Shout {
     fn shout(&self, input: &str) -> String;
+
+    fn shout_mut(&mut self) {}
+}
+
+#[delegatable_trait]
+pub trait Deref {
+    fn deref2(&self) {}
 }
 
 pub struct Cat;
@@ -15,6 +22,8 @@ impl Shout for Cat {
     }
 }
 
+impl Deref for Cat {}
+
 pub struct Dog;
 
 impl Shout for Dog {
@@ -23,12 +32,18 @@ impl Shout for Dog {
     }
 }
 
+impl Deref for Dog {}
+
+#[delegate_to_remote_methods]
+#[delegate(Deref, target_ref = "deref")]
+#[delegate(Shout, target_ref = "deref", target_mut = "deref_mut")]
+impl<T: ?Sized> Box<T> {}
+
 #[derive(Delegate)]
-#[delegate(Shout,automatic_where_clause="false")]
+#[delegate(Shout)]
 pub struct WrappedAnimals(pub Box<dyn Shout>);
 
-
-fn use_it<T: Shout> (shouter: T) {
+fn use_it<T: Shout>(shouter: T) {
     println!("{}", shouter.shout("BAR"));
 }
 

--- a/ambassador/tests/run-pass/same_method_name.rs
+++ b/ambassador/tests/run-pass/same_method_name.rs
@@ -1,0 +1,38 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, Delegate};
+
+#[delegatable_trait]
+pub trait Shout1 {
+    fn shout(&self, input: &str) -> String;
+}
+
+#[delegatable_trait]
+pub trait Shout2 {
+    fn shout(&self);
+}
+
+pub struct Cat;
+
+impl Shout1 for Cat {
+    fn shout(&self, input: &str) -> String {
+        format!("{} - meow!", input)
+    }
+}
+
+impl Shout2 for Cat {
+    fn shout(&self) {
+        println!("meow!")
+    }
+}
+
+#[derive(Delegate)]
+#[delegate(Shout1)]
+#[delegate(Shout2)]
+struct WrappedCat(Cat);
+
+fn main() {
+    let cat = WrappedCat(Cat);
+    println!("{}", Shout1::shout(&cat, ""));
+    Shout2::shout(&cat);
+}


### PR DESCRIPTION
Implements #75 