### PR TITLE
Controlliing inlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 
 <br/>
 
-
 Delegating the implementation of traits to enum variants or fields of a struct normally requires a lot of boilerplate code. Ambassador is an attempt to eliminate that boilerplate by deriving the delegating trait implementation via procedural macros.
 
 **The minimum supported Rust version is 1.68.0.**
@@ -83,6 +82,7 @@ pub struct WrappedAnimals(Cat, Dog);
 ```
 
 #### `#[delegate(..., target = "self")]` - `target="self"`
+
 Types that implement all the methods of a trait without implementing the trait itself,
 can be made to implement that trait by setting `target="self"`.
 This doesn't work for traits with associated types and constants, and requires the where clause to be added explicitly (see `where` key).
@@ -91,7 +91,6 @@ If the type doesn't actually implement the methods (possibly due to an incomplet
 A possible use case of this is when refactoring some methods of a public type into a trait,
 the type still needs to implement the methods outside the trait for semver reasons,
 and using this feature reduces the boilderplate of implementing the trait with the same methods.
-
 
 ```rust
 #[derive(Delegate)]
@@ -110,6 +109,7 @@ impl Cat {
 To make a delegation apply only for certain generic bounds, similar to a [native where clause](https://doc.rust-lang.org/stable/rust-by-example/generics/where.html), you can specify a `where` attribute:
 
 A where clause is automatically applied that makes sure the target field implements the trait being delegated
+
 ```rust
 #[derive(Delegate)]
 #[delegate(Shout, where = "A: Debug")] // <---- Delegate implementation of Shout to .foo field if foo field implements Debug
@@ -117,7 +117,6 @@ pub struct WrappedFoo<A> {
   foo: A,
 }
 ```
-
 
 #### `#[delegate(Shout<X>)]` - trait generics
 
@@ -150,7 +149,6 @@ impl<T: Display> Shout<T> for Cat {
 // We could also use #[delegate(Shout<& 'a str>, generics = "'a")] to only delegate for &str
 pub struct WrappedCat(Cat);
 ```
-
 
 ### For remote traits: `#[delegatable_trait_remote]`
 
@@ -198,6 +196,33 @@ struct WrappedAnimals<A: Shout> {
 ```
 
 Note: Because of the orphan rule `#[delegatable_trait_remote]` and `#[delegate_remote]` can't be combined
+
+## Controlling inlining
+
+Both `#[delegatable_trait]` and `#[delegate]` can set the inlining mode for the
+delegated methods. You have to use the `inline` key with the values `yes` (i.e.,
+`#[inline]`), `no` (no inlining attribute), `always` (i.e.,
+`#[inline(always)]`), or `never` (i.e., `#[inline(never)]`).
+
+The value set in `#[delegatable_trait]` is used as the default for all
+delegations of that trait, but can be overridden by setting the `inline` key in
+`#[delegate]` to a different value. The default inlining mode is `yes` (i.e., `#[inline]`).
+
+```rust
+
+#[delegatable_trait(inline = "always")] // <-------- Change default from "yes" to "always" for all delegations
+pub trait Shout {
+    fn shout(&self, input: &str) -> String;
+}
+
+#[derive(Delegate)]
+#[delegate(Shout)] // <-------- Use default ("always")
+pub struct WrappedDog(Dog);
+
+#[derive(Delegate)]
+#[delegate(Shout, inline = "never")] // <-------- Override inlining mode for this delegation
+pub struct WrappedCat(Cat);
+```
 
 ## Usage Examples
 
@@ -321,4 +346,3 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
 </sub>
-

--- a/ambassador/src/delegate_shared.rs
+++ b/ambassador/src/delegate_shared.rs
@@ -1,7 +1,7 @@
 use crate::util::error;
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use std::cmp::Ordering;
 use syn::ext::IdentExt;
 use syn::parse::{ParseStream, Parser};
@@ -17,12 +17,62 @@ pub(super) trait DelegateTarget: Default {
     fn try_update(&mut self, key: &str, lit: LitStr) -> Option<Result<()>>;
 }
 
+#[derive(Clone, Copy, Default)]
+pub(crate) enum InlineMode {
+    #[default]
+    Yes,
+    No,
+    Always,
+    Never,
+}
+
+impl InlineMode {
+    fn from_lit(lit: &LitStr) -> Result<Self> {
+        match lit.value().as_str() {
+            "yes" => Ok(InlineMode::Yes),
+            "no" => Ok(InlineMode::No),
+            "always" => Ok(InlineMode::Always),
+            "never" => Ok(InlineMode::Never),
+            _ => error!(
+                lit.span(),
+                "invalid value for \"inline\": expected \"yes\", \"no\", \"always\", or \"never\""
+            ),
+        }
+    }
+
+    pub(crate) fn as_bracket_tokens(self) -> TokenStream2 {
+        match self {
+            InlineMode::Yes => quote!([inline]),
+            InlineMode::No => quote!([]),
+            InlineMode::Always => quote!([inline(always)]),
+            InlineMode::Never => quote!([inline(never)]),
+        }
+    }
+}
+
+pub(crate) fn parse_inline_mode(attr: TokenStream2) -> Result<InlineMode> {
+    if attr.is_empty() {
+        return Ok(InlineMode::Yes);
+    }
+    (|input: ParseStream| -> Result<InlineMode> {
+        let key = input.call(Ident::parse_any)?;
+        if key != "inline" {
+            return error!(key.span(), "invalid key for a delegatable_trait attribute");
+        }
+        let _: Token![=] = input.parse()?;
+        let val: LitStr = input.parse()?;
+        InlineMode::from_lit(&val)
+    })
+    .parse2(attr)
+}
+
 #[derive(Default)]
 pub(super) struct DelegateArgs<T: DelegateTarget> {
     pub(crate) target: T,
     pub(crate) where_clauses: Punctuated<WherePredicate, Comma>,
     pub(crate) generics: Vec<GenericParam>,
     pub(crate) inhibit_automatic_where_clause: bool,
+    pub(crate) inline: Option<InlineMode>,
 }
 
 impl<T: DelegateTarget> DelegateArgs<T> {
@@ -42,6 +92,9 @@ impl<T: DelegateTarget> DelegateArgs<T> {
             "automatic_where_clause" => {
                 let auto_where_val: LitBool = lit.parse()?;
                 self.inhibit_automatic_where_clause = !auto_where_val.value;
+            }
+            "inline" => {
+                self.inline = Some(InlineMode::from_lit(&lit)?);
             }
             key => self
                 .target

--- a/ambassador/src/delegate_to_methods.rs
+++ b/ambassador/src/delegate_to_methods.rs
@@ -348,6 +348,10 @@ fn delegate_single_attr(
     let mut where_clause =
         delegate_shared::build_where_clause(args.where_clauses, implementer.where_clause.as_ref());
 
+    let inline_attr = match args.inline {
+        Some(mode) => mode.as_bracket_tokens(),
+        None => TokenStream2::new(),
+    };
     let mut added_deref = false;
     let delegate_ty = args
         .target
@@ -358,7 +362,7 @@ fn delegate_single_attr(
     add_auto_where_clause(&mut where_clause, &trait_path_full, delegate_ty.as_ref());
     let mut res = quote! {
         impl <#(#impl_generics,)*> #trait_path_full for #implementer_ty #where_clause {
-            #macro_name!{body_struct(<#trait_generics_p>, #delegate_ty, (#(#owned_ident())*), (#(#ref_ident())*), (#(#ref_mut_ident())*))}
+            #macro_name!{body_struct(#inline_attr <#trait_generics_p>, #delegate_ty, (#(#owned_ident())*), (#(#ref_ident())*), (#(#ref_mut_ident())*))}
         }
     };
 

--- a/ambassador/src/derive.rs
+++ b/ambassador/src/derive.rs
@@ -169,12 +169,16 @@ fn delegate_single_attr(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let mut where_clause = delegate_shared::build_where_clause(args.where_clauses, where_clause);
     let impl_generics = delegate_shared::merge_impl_generics(impl_generics, args.generics);
+    let inline_attr = match args.inline {
+        Some(mode) => mode.as_bracket_tokens(),
+        None => TokenStream2::new(),
+    };
     let implementer_ident = &implementer.ty;
     use {DelegateImplementerInfo::*, DelegateTarget::*};
     let res = match (&args.target, &implementer.info) {
         (TrgSelf, _) => quote! {
             impl <#(#impl_generics,)*> #trait_path_full for #implementer_ident #ty_generics #where_clause {
-                #macro_name!{body_self(<#trait_generics_p>)}
+                #macro_name!{body_self(#inline_attr <#trait_generics_p>)}
             }
         },
         (Field(field), Enum {..}) => return error!(
@@ -202,7 +206,7 @@ fn delegate_single_attr(
                     use super::*;
                     #macro_name!{use_assoc_ty_bounds}
                     impl <#(#impl_generics,)*> #trait_path_full for #implementer_ident #ty_generics #where_clause {
-                        #macro_name!{body_enum(<#trait_generics_p>, #first_type, (#(#other_types),*), (#(#implementer_ident::#variant_idents),*))}
+                        #macro_name!{body_enum(#inline_attr <#trait_generics_p>, #first_type, (#(#other_types),*), (#(#implementer_ident::#variant_idents),*))}
                     }
                 }
             }
@@ -220,7 +224,7 @@ fn delegate_single_attr(
 
             quote! {
                 impl <#(#impl_generics,)*> #trait_path_full for #implementer_ident #ty_generics #where_clause {
-                    #macro_name!{body_struct(<#trait_generics_p>, #field_type, #field_ident)}
+                    #macro_name!{body_struct(#inline_attr <#trait_generics_p>, #field_type, #field_ident)}
                 }
             }
         }
@@ -238,7 +242,7 @@ fn delegate_single_attr(
 
             quote! {
                 impl <#(#impl_generics,)*> #trait_path_full for #implementer_ident #ty_generics #where_clause {
-                    #macro_name!{body_struct(<#trait_generics_p>, #field_type, #field_ident)}
+                    #macro_name!{body_struct(#inline_attr <#trait_generics_p>, #field_type, #field_ident)}
                 }
             }
         }

--- a/ambassador/src/lib.rs
+++ b/ambassador/src/lib.rs
@@ -177,6 +177,7 @@ mod util;
 use proc_macro::TokenStream;
 use quote::quote;
 
+use crate::delegate_shared::parse_inline_mode;
 use crate::register::build_register_trait;
 
 /// Delegate the implementation of a trait to a struct field/enum variants by adding `#[derive(Delegate)]` and its associated attribute `#[delegate(Trait)]` to it:
@@ -771,9 +772,13 @@ pub fn delegate_remote(_attr: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 #[proc_macro_attribute]
-pub fn delegatable_trait(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn delegatable_trait(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let inline_mode = match parse_inline_mode(attr.into()) {
+        Ok(mode) => mode,
+        Err(err) => return err.to_compile_error().into(),
+    };
     let original_item: syn::ItemTrait = syn::parse(item).unwrap();
-    let register_trait = build_register_trait(&original_item);
+    let register_trait = build_register_trait(&original_item, inline_mode);
 
     let expanded = quote! {
         #original_item
@@ -809,9 +814,13 @@ pub fn delegatable_trait(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// pub struct WrappedCat(Cat);
 /// ```
 #[proc_macro_attribute]
-pub fn delegatable_trait_remote(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn delegatable_trait_remote(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let inline_mode = match parse_inline_mode(attr.into()) {
+        Ok(mode) => mode,
+        Err(err) => return err.to_compile_error().into(),
+    };
     let original_item: syn::ItemTrait = syn::parse(item).unwrap();
-    let register_trait = build_register_trait(&original_item);
+    let register_trait = build_register_trait(&original_item, inline_mode);
 
     TokenStream::from(register_trait)
 }

--- a/ambassador/src/register.rs
+++ b/ambassador/src/register.rs
@@ -58,7 +58,10 @@ impl CfgNames {
     }
 }
 
-pub fn build_register_trait(original_item: &ItemTrait, inline_mode: InlineMode) -> TokenStream {
+pub(crate) fn build_register_trait(
+    original_item: &ItemTrait,
+    inline_mode: InlineMode,
+) -> TokenStream {
     let trait_ident = &original_item.ident;
     let macro_name = macro_name(trait_ident);
     let macro_def = quote::format_ident!("_{}", macro_name);

--- a/ambassador/src/register.rs
+++ b/ambassador/src/register.rs
@@ -1,3 +1,4 @@
+use crate::delegate_shared::InlineMode;
 use crate::util::{error, process_results, receiver_type, ReceiverType};
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream, TokenTree};
@@ -57,7 +58,7 @@ impl CfgNames {
     }
 }
 
-pub fn build_register_trait(original_item: &ItemTrait) -> TokenStream {
+pub fn build_register_trait(original_item: &ItemTrait, inline_mode: InlineMode) -> TokenStream {
     let trait_ident = &original_item.ident;
     let macro_name = macro_name(trait_ident);
     let macro_def = quote::format_ident!("_{}", macro_name);
@@ -80,26 +81,41 @@ pub fn build_register_trait(original_item: &ItemTrait) -> TokenStream {
     let gen_idents_pat: TokenStream = gen_idents.into_iter().map(|id| quote! {$ #id ,}).collect();
     let vis = &original_item.vis;
     let cfg_definitions = cfg_names.definitions(&macro_name, vis);
+    let default_inline_bracket = inline_mode.as_bracket_tokens();
     quote! {
         #[macro_export]
         #[doc(hidden)]
         macro_rules! #macro_def {
+            // Override arms: explicit inline specifier in brackets
+            (body_struct([$($inline:meta)*] <#gen_matcher>, $ty:ty, $field_ident:tt)) => {
+                #macro_name!{body_struct([$($inline)*] <#gen_idents_pat>, $ty, ($field_ident), ($field_ident), ($field_ident))}
+            };
+            (body_struct([$($inline:meta)*] <#gen_matcher>, $ty:ty, ($($ident_owned:tt)*), ($($ident_ref:tt)*), ($($ident_ref_mut:tt)*))) => {
+                #(#struct_items)*
+            };
+            // Default arms: redirect using trait-level default
             (body_struct(<#gen_matcher>, $ty:ty, $field_ident:tt)) => {
-                #macro_name!{body_struct(<#gen_idents_pat>, $ty, ($field_ident), ($field_ident), ($field_ident))}
+                #macro_name!{body_struct(#default_inline_bracket <#gen_idents_pat>, $ty, ($field_ident), ($field_ident), ($field_ident))}
             };
             (body_struct(<#gen_matcher>, $ty:ty, ($($ident_owned:tt)*), ($($ident_ref:tt)*), ($($ident_ref_mut:tt)*))) => {
-                #(#struct_items)*
+                #macro_name!{body_struct(#default_inline_bracket <#gen_idents_pat>, $ty, ($($ident_owned)*), ($($ident_ref)*), ($($ident_ref_mut)*))}
             };
             (resolve_path($err:literal, $(& $(mut)?)?,  $s:ident.$field:ident$($t:tt)+)) => {$s.$field$($t)*};
             (resolve_path($err:literal, $(& $(mut $($emp:lifetime)?)?)?,  $s:ident.$field:tt)) => {$(& $(mut $($emp)?)?)?  $s.$field};
             (resolve_path($err:literal, $(& $(mut)?)?,  $s:ident.)) => {
                 compile_error! {$err}
             };
-            (body_enum(<#gen_matcher>, $ty:ty, ($( $other_tys:ty ),*), ($( $variants:path ),+))) => {
+            (body_enum([$($inline:meta)*] <#gen_matcher>, $ty:ty, ($( $other_tys:ty ),*), ($( $variants:path ),+))) => {
                 #(#enum_items)*
             };
-            (body_self(<#gen_matcher>)) => {
+            (body_enum(<#gen_matcher>, $ty:ty, ($( $other_tys:ty ),*), ($( $variants:path ),+))) => {
+                #macro_name!{body_enum(#default_inline_bracket <#gen_idents_pat>, $ty, ($($other_tys),*), ($($variants),+))}
+            };
+            (body_self([$($inline:meta)*] <#gen_matcher>)) => {
                 #(#self_items)*
+            };
+            (body_self(<#gen_matcher>)) => {
+                #macro_name!{body_self(#default_inline_bracket <#gen_idents_pat>)}
             };
             (use_assoc_ty_bounds) => {
                 #assoc_ty_bounds
@@ -209,7 +225,7 @@ fn build_method(
     extr_attrs: TokenStream,
 ) -> TokenStream {
     quote! {
-        #[inline]
+        $(#[$inline])*
         #[allow(unused_braces)]
         #extr_attrs
         #method_sig {

--- a/ambassador/tests/run-pass/inline.rs
+++ b/ambassador/tests/run-pass/inline.rs
@@ -1,0 +1,154 @@
+extern crate ambassador;
+
+use ambassador::{delegatable_trait, Delegate};
+
+#[delegatable_trait]
+pub trait Shout {
+    fn shout(&self) -> String;
+}
+
+#[delegatable_trait(inline = "no")]
+pub trait Whisper {
+    fn whisper(&self) -> String;
+}
+
+#[delegatable_trait(inline = "always")]
+pub trait Sing {
+    fn sing(&self) -> String;
+}
+
+#[delegatable_trait(inline = "never")]
+pub trait Dance {
+    fn dance(&self) -> String;
+}
+
+pub struct Cat;
+
+impl Shout for Cat {
+    fn shout(&self) -> String {
+        "meow!".to_owned()
+    }
+}
+impl Whisper for Cat {
+    fn whisper(&self) -> String {
+        "mew".to_owned()
+    }
+}
+impl Sing for Cat {
+    fn sing(&self) -> String {
+        "la la".to_owned()
+    }
+}
+impl Dance for Cat {
+    fn dance(&self) -> String {
+        "tap".to_owned()
+    }
+}
+
+pub struct Dog;
+
+impl Shout for Dog {
+    fn shout(&self) -> String {
+        "woof!".to_owned()
+    }
+}
+impl Whisper for Dog {
+    fn whisper(&self) -> String {
+        "wrf".to_owned()
+    }
+}
+impl Sing for Dog {
+    fn sing(&self) -> String {
+        "howl".to_owned()
+    }
+}
+impl Dance for Dog {
+    fn dance(&self) -> String {
+        "spin".to_owned()
+    }
+}
+
+// Default inline (yes) from trait, no override
+#[derive(Delegate)]
+#[delegate(Shout)]
+pub enum Animals {
+    Cat(Cat),
+    Dog(Dog),
+}
+
+// Trait default is "no", but override to "always" at delegation site
+#[derive(Delegate)]
+#[delegate(Whisper, inline = "always")]
+pub enum AnimalsWhisperOverride {
+    Cat(Cat),
+    Dog(Dog),
+}
+
+// Trait default is "always", use it
+#[derive(Delegate)]
+#[delegate(Sing)]
+pub enum AnimalsSing {
+    Cat(Cat),
+    Dog(Dog),
+}
+
+// Trait default is "never", but override to "yes" at delegation site
+#[derive(Delegate)]
+#[delegate(Dance, inline = "yes")]
+pub enum AnimalsDanceOverride {
+    Cat(Cat),
+    Dog(Dog),
+}
+
+// All four inline modes on delegate, with default trait (inline=yes)
+#[derive(Delegate)]
+#[delegate(Shout, inline = "yes")]
+pub struct WrappedCatYes(Cat);
+
+#[derive(Delegate)]
+#[delegate(Shout, inline = "no")]
+pub struct WrappedCatNo(Cat);
+
+#[derive(Delegate)]
+#[delegate(Shout, inline = "always")]
+pub struct WrappedCatAlways(Cat);
+
+#[derive(Delegate)]
+#[delegate(Shout, inline = "never")]
+pub struct WrappedCatNever(Cat);
+
+// Use trait defaults without override (structs)
+#[derive(Delegate)]
+#[delegate(Whisper)]
+pub struct WrappedCatWhisper(Cat);
+
+#[derive(Delegate)]
+#[delegate(Sing)]
+pub struct WrappedCatSing(Cat);
+
+#[derive(Delegate)]
+#[delegate(Dance)]
+pub struct WrappedCatDance(Cat);
+
+pub fn main() {
+    let a = Animals::Cat(Cat);
+    assert_eq!(a.shout(), "meow!");
+
+    let a = AnimalsWhisperOverride::Dog(Dog);
+    assert_eq!(a.whisper(), "wrf");
+
+    let a = AnimalsSing::Cat(Cat);
+    assert_eq!(a.sing(), "la la");
+
+    let a = AnimalsDanceOverride::Dog(Dog);
+    assert_eq!(a.dance(), "spin");
+
+    assert_eq!(WrappedCatYes(Cat).shout(), "meow!");
+    assert_eq!(WrappedCatNo(Cat).shout(), "meow!");
+    assert_eq!(WrappedCatAlways(Cat).shout(), "meow!");
+    assert_eq!(WrappedCatNever(Cat).shout(), "meow!");
+
+    assert_eq!(WrappedCatWhisper(Cat).whisper(), "mew");
+    assert_eq!(WrappedCatSing(Cat).sing(), "la la");
+    assert_eq!(WrappedCatDance(Cat).dance(), "tap");
+}


### PR DESCRIPTION
This is a proposal for controlling the inlining policy. There's a global setting (default: as now) and a local override for maximum flexibility.

I'm having some problems to compile the tests—I guess it's a compiler-version problem, but ATM trying to use the +1.68 toolchain gives me HTTP errors.